### PR TITLE
Add `write-all` permission for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   release:
+    permissions: write-all
     name: ${{ matrix.target }}
     runs-on: ${{ matrix.os }}
     strategy:


### PR DESCRIPTION
There's been a lot of _fun_ issues with CI these past couple of releases. Hopefully things are smoother sailing from now on