### PR TITLE
Fix exclude for `manual_test_data`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ rust-version = "1.72.1"
 exclude = [
     "/ci/*",
     "/.github/*",
-    "/tests/manual_test_data/*",
+    "/assets/manual_test_data/*",
 ]
 keywords = ["markdown", "viewer", "gpu"]
 


### PR DESCRIPTION
The exclude for the manual test data got broken when things got shifted around