### PR TITLE
Add a very basic dependabot workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This should only run dependabot on github actions because I'm not ready to open the firehouse of including `Cargo.toml` updates too

The reason that I'm adding this is because it's a simple piece of automation and no person regularly checks the action versions for CI in reality, so let's have a bot handle it for us :D