### PR TITLE
Tweak CI run trigger to run on fewer pushes

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+    - main
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Before PRs would consistently trigger two identical sets of checks because they would hit the `push` _and_ `pull_request` trigger. Now it only runs on `push`es to `main` (e.g. branches merging)