### PR TITLE
Ensure that we can always deserialize the default keybindings

### DIFF
--- a/src/keybindings/keybindings.rs
+++ b/src/keybindings/keybindings.rs
@@ -6,7 +6,7 @@ use super::{action::Action, KeyCombo};
 
 /// A list of [`keybindings`](KeyCombo) each associated with an [`Action`].
 #[derive(Debug, Clone, Deserialize, PartialEq, Eq)]
-pub struct Keybindings(Vec<(Action, KeyCombo)>);
+pub struct Keybindings(pub(crate) Vec<(Action, KeyCombo)>);
 
 impl Keybindings {
     /// Returns an iterator over the [`Action`]s and [`KeyCombo`]s


### PR DESCRIPTION
This acts as a guard to catch when someone adds an `Action` but forgets a mapping from `FlatAction` meaning that we can't deserialize it. The idea is that virtually every action is bound by default, so you're reminded to add the mapping when this test fails