### PR TITLE
Fix crash when rendering headerless table

### DIFF
--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -399,10 +399,15 @@ impl Renderer {
                             }
                         }
                     }
-                    let last_header_node = layout.headers.last().unwrap();
-                    let y = last_header_node.location.y
-                        + last_header_node.size.height
-                        + TABLE_ROW_GAP / 2.;
+                    let y = layout
+                        .headers
+                        .last()
+                        .map(|last_header_node| {
+                            last_header_node.location.y
+                                + last_header_node.size.height
+                                + TABLE_ROW_GAP / 2.0
+                        })
+                        .unwrap_or(0.0);
                     let x = layout
                         .headers
                         .last()


### PR DESCRIPTION
Fixes #261

```html
<table>
  <tr>
    <td>one</td>
    <td>two</td>
  </tr>
  <tr>
    <td>three</td>
    <td>four/td>
  </tr>
</table>
```

renders as

![image](https://github.com/Inlyne-Project/inlyne/assets/30302768/0ed3ad28-6036-4c9c-a3c3-d9d29a7bf6c6)
