### PR TITLE
Add the automatic creation of config files and the ability to open them with the CLI.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -782,6 +782,10 @@ fn main() -> anyhow::Result<()> {
                 .join("inlyne.toml");
 
             if !config_path.is_file() {
+                tracing::info!(
+                    "No config found. Creating a new config at: {}",
+                    config_path.display()
+                );
                 Config::create_default_config(&config_path)?;
             }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,7 @@ use tracing_subscriber::prelude::*;
 use tracing_subscriber::util::SubscriberInitExt;
 use utils::{ImageCache, Point, Rect, Size};
 
-use crate::opts::Commands;
+use crate::opts::{Commands, ConfigCmd};
 use anyhow::Context;
 use clap::Parser;
 use taffy::Taffy;
@@ -774,6 +774,18 @@ fn main() -> anyhow::Result<()> {
 
             let inlyne = Inlyne::new(opts)?;
             inlyne.run();
+        }
+        Commands::Config(ConfigCmd::Open) => {
+            let config_path = dirs::config_dir()
+                .context("Failed to find the configuration directory")?
+                .join("inlyne")
+                .join("inlyne.toml");
+
+            if !config_path.is_file() {
+                Config::create_default_config(&config_path)?;
+            }
+
+            edit::edit_file(config_path)?;
         }
     }
 

--- a/src/opts/cli.rs
+++ b/src/opts/cli.rs
@@ -64,6 +64,8 @@ impl Cli {
 #[derive(Subcommand, Debug, PartialEq, Clone)]
 pub enum Commands {
     View(View),
+    #[command(subcommand)]
+    Config(ConfigCmd),
 }
 
 /// View markdown a file with inlyne
@@ -89,4 +91,11 @@ pub struct View {
     /// Maximum width of page in pixels
     #[arg(short = 'w', long = "page-width")]
     pub page_width: Option<f32>,
+}
+
+/// Configuration related things
+#[derive(Subcommand, PartialEq, Clone, Debug)]
+pub enum ConfigCmd {
+    /// Opens the configuration file in the default text editor
+    Open,
 }

--- a/src/opts/config.rs
+++ b/src/opts/config.rs
@@ -1,5 +1,6 @@
-use std::fs::read_to_string;
-use std::path::Path;
+use std::fs::{create_dir_all, read_to_string};
+use std::io::Write;
+use std::path::{Path, PathBuf};
 
 use super::ThemeType;
 use crate::color;
@@ -108,10 +109,21 @@ impl Config {
         let config_path = config_dir.join("inlyne").join("inlyne.toml");
 
         if !config_path.is_file() {
-            return Ok(Self::default());
+            Self::create_default_config(&config_path)?
         }
 
         Self::load_from_file(&config_path)
+    }
+
+    pub fn create_default_config(path: &PathBuf) -> anyhow::Result<()> {
+        create_dir_all(
+            path.parent()
+                .context("Could not find parent directory of path.")?,
+        )?;
+
+        let mut file = std::fs::File::create(path)?;
+        file.write_all(include_bytes!("../../inlyne.default.toml"))?;
+        Ok(())
     }
 }
 

--- a/src/opts/mod.rs
+++ b/src/opts/mod.rs
@@ -6,7 +6,7 @@ mod tests;
 use std::path::Path;
 
 use crate::color;
-pub use cli::{Cli, Commands, ThemeType, View};
+pub use cli::{Cli, Commands, ConfigCmd, ThemeType, View};
 pub use config::{Config, FontOptions, KeybindingsSection};
 
 use crate::history::History;


### PR DESCRIPTION
In #131 the two things (to automatically create a config file and the ability to open them) were mentioned.
This pr adds the CLI option `inlyne config open` and it places the [inlyne.default.toml](https://github.com/Inlyne-Project/inlyne/blob/main/inlyne.default.toml) as `inlyne.toml` in the config directory when no config exists.