### PR TITLE
feat: Setup initial metrics infrastructure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,7 +506,7 @@ version = "4.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90239a040c80f5e14809ca132ddc4176ab33d5e17e49691793296e3fcb34d72f"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.52",
@@ -1163,6 +1163,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
 name = "flate2"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1618,6 +1624,12 @@ dependencies = [
 
 [[package]]
 name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
@@ -1642,11 +1654,11 @@ checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
 name = "home"
-version = "0.5.9"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1919,9 +1931,13 @@ dependencies = [
  "insta",
  "lyon",
  "lz4_flex",
+ "metrics",
+ "metrics-exporter-tcp",
+ "metrics-util",
  "notify",
  "notify-debouncer-full",
  "open",
+ "parking_lot",
  "pollster",
  "pretty_assertions",
  "raw-window-handle",
@@ -2023,6 +2039,15 @@ checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
 dependencies = [
  "is-docker",
  "once_cell",
+]
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
 ]
 
 [[package]]
@@ -2362,6 +2387,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "metrics"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2be3cbd384d4e955b231c895ce10685e3d8260c5ccffae898c96c723b0772835"
+dependencies = [
+ "ahash 0.8.11",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-exporter-tcp"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a62a4304fc3e0fe66e94c6f577fc8f594ee72f9231de206f69d28ea8b35ec545"
+dependencies = [
+ "bytes",
+ "crossbeam-channel",
+ "home",
+ "metrics",
+ "mio",
+ "prost",
+ "prost-build",
+ "prost-types",
+ "tracing",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b07a5eb561b8cbc16be2d216faf7757f9baf3bfb94dbb0fae3df8387a5bb47f"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.14.3",
+ "metrics",
+ "num_cpus",
+ "sketches-ddsketch",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2388,6 +2454,12 @@ dependencies = [
  "wasi",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "multimap"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "naga"
@@ -2787,6 +2859,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
+name = "petgraph"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.2.5",
+]
+
+[[package]]
 name = "phf"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2930,6 +3012,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22686f4785f02a4fcc856d3b3bb19bf6c8160d103f7a99cc258bddd0251dc7f2"
 
 [[package]]
+name = "portable-atomic"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7170ef9988bc169ba16dd36a7fa041e5c4cbeb6a35b76d4c03daded371eae7c0"
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2958,6 +3046,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a41cf62165e97c7f814d2221421dbb9afcbcdb0a88068e5ea206e19951c2cbb5"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.52",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2981,6 +3079,60 @@ name = "profiling"
 version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "332cd62e95873ea4f41f3dfd6bbbfc5b52aec892d7e8d534197c4720a0bbbab2"
+
+[[package]]
+name = "prost"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c289cda302b98a28d40c8b3b90498d6e526dd24ac2ecea73e4e491685b94a"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c55e02e35260070b6f716a2423c2ff1c3bb1642ddca6f99e1f26d06268a0e2d2"
+dependencies = [
+ "bytes",
+ "heck 0.4.1",
+ "itertools",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph",
+ "prettyplease",
+ "prost",
+ "prost-types",
+ "regex",
+ "syn 2.0.52",
+ "tempfile",
+ "which",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efb6c9a1dd1def8e2124d17e83a20af56f1570d6c2d2bd9e266ccb768df3840e"
+dependencies = [
+ "anyhow",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.52",
+]
+
+[[package]]
+name = "prost-types"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "193898f59edcf43c26227dcd4c8427f00d99d61e95dcde58dabd49fa291d470e"
+dependencies = [
+ "prost",
+]
 
 [[package]]
 name = "qoi"
@@ -3548,6 +3700,12 @@ name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85636c14b73d81f541e525f585c0a2109e6744e1565b5c1668e31c70c10ed65c"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,9 +75,11 @@ edit = "0.1.5"
 anstream = "0.6.13"
 anstyle = "1.0.6"
 metrics = "0.22.3"
-metrics-exporter-tcp = "0.9.0"
 metrics-util = { version = "0.16.3", default-features = false, features = ["registry", "summary"] }
 parking_lot = "0.12.1"
+
+[target.'cfg(inlyne_tcp_metrics)'.dependencies]
+metrics-exporter-tcp = "0.9.0"
 
 [profile.release]
 strip = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,6 +74,10 @@ raw-window-handle = "0.5.2"
 edit = "0.1.5"
 anstream = "0.6.13"
 anstyle = "1.0.6"
+metrics = "0.22.3"
+metrics-exporter-tcp = "0.9.0"
+metrics-util = { version = "0.16.3", default-features = false, features = ["registry", "summary"] }
+parking_lot = "0.12.1"
 
 [profile.release]
 strip = true

--- a/src/main.rs
+++ b/src/main.rs
@@ -790,6 +790,7 @@ fn main() -> anyhow::Result<()> {
                         metrics::set_global_recorder(recorder)
                             .expect("Failed setting metrics recorder");
                     }
+                    #[cfg(inlyne_tcp_metrics)]
                     MetricsExporter::Tcp => metrics_exporter_tcp::TcpBuilder::new()
                         .install()
                         .expect("Failed to install TCP metrics server"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ pub mod history;
 pub mod image;
 pub mod interpreter;
 mod keybindings;
+mod metrics;
 pub mod opts;
 mod panic_hook;
 pub mod positioner;
@@ -36,12 +37,14 @@ use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::mpsc::{self, channel};
 use std::sync::{Arc, Mutex};
+use std::time::Instant;
 
 use file_watcher::Watcher;
 use image::{Image, ImageData};
 use interpreter::HtmlInterpreter;
 use keybindings::action::{Action, HistDirection, VertDirection, Zoom};
 use keybindings::{Key, KeyCombos, ModifiedKey};
+use metrics::{histogram, HistTag};
 use opts::{Cli, Config, Opts};
 use positioner::{Positioned, Row, Section, Spacer, DEFAULT_MARGIN, DEFAULT_PADDING};
 use raw_window_handle::HasRawDisplayHandle;
@@ -52,7 +55,7 @@ use tracing_subscriber::prelude::*;
 use tracing_subscriber::util::SubscriberInitExt;
 use utils::{ImageCache, Point, Rect, Size};
 
-use crate::opts::{Commands, ConfigCmd};
+use crate::opts::{Commands, ConfigCmd, MetricsExporter};
 use anyhow::Context;
 use clap::Parser;
 use taffy::Taffy;
@@ -218,6 +221,8 @@ impl Inlyne {
                 .map(|mut queue| queue.drain(..).collect::<Vec<Element>>())
         };
         if let Ok(queue) = queue {
+            let positioning_start = Instant::now();
+
             for element in queue {
                 // Position element and add it to elements
                 let mut positioned_element = Positioned::new(element);
@@ -234,6 +239,8 @@ impl Inlyne {
                         + positioned_element.bounds.as_ref().unwrap().size.1;
                 elements.push(positioned_element);
             }
+
+            histogram!(HistTag::Positioner).record(positioning_start.elapsed());
         }
     }
 
@@ -301,6 +308,7 @@ impl Inlyne {
                     }
                 },
                 Event::RedrawRequested(_) => {
+                    let redraw_start = Instant::now();
                     Self::position_queued_elements(
                         &self.element_queue,
                         &mut self.renderer,
@@ -314,6 +322,8 @@ impl Inlyne {
                     if selecting {
                         selection_cache = self.renderer.selection_text.clone();
                     }
+
+                    histogram!(HistTag::Redraw).record(redraw_start.elapsed());
                 }
                 Event::WindowEvent { event, .. } => match event {
                     WindowEvent::Resized(size) => pending_resize = Some(size),
@@ -773,6 +783,23 @@ fn main() -> anyhow::Result<()> {
             };
             let opts = Opts::parse_and_load_from(view, config)?;
 
+            if let Some(exporter) = &opts.metrics {
+                match exporter {
+                    MetricsExporter::Log => {
+                        let recorder = metrics::LogRecorder::default();
+                        metrics::set_global_recorder(recorder)
+                            .expect("Failed setting metrics recorder");
+                    }
+                    MetricsExporter::Tcp => metrics_exporter_tcp::TcpBuilder::new()
+                        .install()
+                        .expect("Failed to install TCP metrics server"),
+                };
+            }
+
+            for tag in HistTag::iter() {
+                tag.set_global_description();
+            }
+
             let inlyne = Inlyne::new(opts)?;
             inlyne.run();
         }
@@ -783,7 +810,7 @@ fn main() -> anyhow::Result<()> {
                 .join("inlyne.toml");
 
             if !config_path.is_file() {
-                tracing::info!(
+                tracing::warn!(
                     "No config found. Creating a new config at: {}",
                     config_path.display()
                 );

--- a/src/metrics/counter.rs
+++ b/src/metrics/counter.rs
@@ -1,0 +1,38 @@
+use super::{Metric, Unit, SPAN_LEVEL};
+
+use metrics::{CounterFn, Key};
+use parking_lot::Mutex;
+use tracing::{debug, span};
+
+pub struct Handle(pub Mutex<Metric<u64>>);
+
+impl Handle {
+    pub fn new(key: Key, unit: Option<Unit>) -> Self {
+        Self(Metric::new(key, 0, unit))
+    }
+}
+
+impl CounterFn for Handle {
+    fn absolute(&self, value: u64) {
+        let mut counter = self.0.lock();
+        counter.value = value;
+
+        let key = counter.key.name();
+        let unit = counter.unit.as_canonical_label();
+        let span = span!(SPAN_LEVEL, "counter", %key);
+        let _enter = span.enter();
+        debug!("set to {value}{unit}");
+    }
+
+    fn increment(&self, value: u64) {
+        let mut counter = self.0.lock();
+        counter.value = counter.value.saturating_add(value);
+
+        let key = counter.key.name();
+        let unit = counter.unit.as_canonical_label();
+        let counter_value = counter.value;
+        let span = span!(SPAN_LEVEL, "counter", %key);
+        let _enter = span.enter();
+        debug!("incremented by {value}{unit} to {counter_value}{unit}",);
+    }
+}

--- a/src/metrics/gauge.rs
+++ b/src/metrics/gauge.rs
@@ -1,0 +1,50 @@
+use super::{Metric, Unit, SPAN_LEVEL};
+
+use metrics::{GaugeFn, Key};
+use parking_lot::Mutex;
+use tracing::{debug, span};
+
+pub struct Handle(pub Mutex<Metric<f64>>);
+
+impl Handle {
+    pub fn new(key: Key, unit: Option<Unit>) -> Self {
+        Self(Metric::new(key, 0.0, unit))
+    }
+}
+
+impl GaugeFn for Handle {
+    fn increment(&self, value: f64) {
+        let mut gauge = self.0.lock();
+        gauge.value += value;
+
+        let key = gauge.key.name();
+        let unit = gauge.unit.as_canonical_label();
+        let gauge_value = gauge.value;
+        let span = span!(SPAN_LEVEL, "gauge", %key);
+        let _enter = span.enter();
+        debug!("incremented by {value}{unit} to {gauge_value}{unit}",);
+    }
+
+    fn decrement(&self, value: f64) {
+        let mut gauge = self.0.lock();
+        gauge.value -= value;
+
+        let key = gauge.key.name();
+        let unit = gauge.unit.as_canonical_label();
+        let gauge_value = gauge.value;
+        let span = span!(SPAN_LEVEL, "gauge", %key);
+        let _enter = span.enter();
+        debug!("decremented by {value}{unit} to {gauge_value}{unit}",);
+    }
+
+    fn set(&self, value: f64) {
+        let mut gauge = self.0.lock();
+        gauge.value = value;
+
+        let key = gauge.key.name();
+        let unit = gauge.unit.as_canonical_label();
+        let span = span!(SPAN_LEVEL, "gauge", %key);
+        let _enter = span.enter();
+        debug!("set to {value}{unit}",);
+    }
+}

--- a/src/metrics/hist.rs
+++ b/src/metrics/hist.rs
@@ -1,0 +1,128 @@
+use std::time::Duration;
+
+use super::{describe_histogram, Metric, Unit, SPAN_LEVEL};
+
+use metrics::{HistogramFn, Key, KeyName};
+use metrics_util::Summary;
+use parking_lot::Mutex;
+use tracing::{debug, info, span, trace};
+
+#[derive(Clone, Copy)]
+pub enum Tag {
+    ImageDecompress,
+    ImageLoad,
+    Positioner,
+    Redraw,
+    Reposition,
+}
+
+impl Tag {
+    pub fn set_global_description(self) {
+        describe_histogram!(self.as_str(), self.unit(), self.desc_text());
+    }
+
+    pub fn iter() -> TagIter {
+        TagIter(Some(Tag::ImageDecompress))
+    }
+
+    fn as_str(self) -> &'static str {
+        match self {
+            Tag::ImageDecompress => "image.decompress",
+            Tag::ImageLoad => "image.load",
+            Tag::Positioner => "positioner",
+            Tag::Redraw => "redraw",
+            Tag::Reposition => "reposition",
+        }
+    }
+
+    pub fn desc_text(self) -> &'static str {
+        match self {
+            Self::ImageDecompress => "Decompressing image data to render",
+            Self::ImageLoad => "Reading, decoding, and compressing the raw image data",
+            Self::Positioner => "Positioning all of the elements",
+            Self::Redraw => "A full redraw",
+            Self::Reposition => "Repositioning all of the elements in the queue",
+        }
+    }
+
+    pub fn unit(self) -> Unit {
+        match self {
+            Self::ImageDecompress
+            | Self::ImageLoad
+            | Self::Positioner
+            | Self::Redraw
+            | Self::Reposition => Unit::Seconds,
+        }
+    }
+}
+
+impl From<Tag> for KeyName {
+    fn from(tag: Tag) -> Self {
+        tag.as_str().into()
+    }
+}
+
+// TODO(cosmic): we can switch to strum if we start doing this a lot
+pub struct TagIter(Option<Tag>);
+
+impl Iterator for TagIter {
+    type Item = Tag;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let next = std::mem::take(&mut self.0)?;
+        self.0 = match next {
+            Tag::ImageDecompress => Some(Tag::ImageLoad),
+            Tag::ImageLoad => Some(Tag::Positioner),
+            Tag::Positioner => Some(Tag::Redraw),
+            Tag::Redraw => Some(Tag::Reposition),
+            Tag::Reposition => None,
+        };
+        Some(next)
+    }
+}
+
+pub struct Handle(pub Mutex<Metric<Summary>>);
+
+impl Handle {
+    pub fn new(key: Key, unit: Option<Unit>) -> Self {
+        let summary = Summary::with_defaults();
+        Self(Metric::new(key, summary, unit))
+    }
+}
+
+impl HistogramFn for Handle {
+    fn record(&self, value: f64) {
+        let mut hist = self.0.lock();
+        hist.value.add(value);
+
+        let p50 = hist.value.quantile(0.5).expect("Has values");
+        let p99 = hist.value.quantile(0.99).expect("Has values");
+        let p999 = hist.value.quantile(0.999).expect("Has values");
+        let key = hist.key.name();
+        let span = span!(SPAN_LEVEL, "histogram", %key);
+        let _enter = span.enter();
+        // `Duration`s automatically get consumed as seconds by `IntoF64`, so special case
+        // `Unit::Seconds` for durations specifically
+        if hist.unit == Unit::Seconds {
+            let value = Duration::from_secs_f64(value);
+            let p50 = Duration::from_secs_f64(p50);
+            let p99 = Duration::from_secs_f64(p99);
+            let p999 = Duration::from_secs_f64(p999);
+            let msg =
+                format!("record {value:.02?} | p50 {p50:.02?} | p99 {p99:.02?} | p999 {p999:.02?}");
+            if value < p50 {
+                trace!("{msg}");
+            } else if value < p99 {
+                debug!("{msg}");
+            } else {
+                info!("{msg}");
+            }
+        } else {
+            let unit = hist.unit.as_canonical_label();
+            debug!(
+                "record {value:.02} | p50 {p50:.02}{unit} | p99 {p99:.02}{unit} | \
+                p999 {p999:.02}{unit}"
+            );
+        }
+    }
+}

--- a/src/metrics/log_recorder.rs
+++ b/src/metrics/log_recorder.rs
@@ -1,0 +1,69 @@
+use std::sync::Arc;
+
+use super::{counter, gauge, hist, Unit};
+
+use metrics::{Counter, Gauge, Histogram, Key, KeyName, Metadata, SharedString};
+use metrics_util::registry::{Registry, Storage};
+
+struct MetricStore;
+
+impl Storage<Key> for MetricStore {
+    type Counter = Arc<counter::Handle>;
+    type Gauge = Arc<gauge::Handle>;
+    type Histogram = Arc<hist::Handle>;
+
+    fn counter(&self, key: &Key) -> Self::Counter {
+        Arc::new(counter::Handle::new(key.to_owned(), None))
+    }
+
+    fn gauge(&self, key: &Key) -> Self::Gauge {
+        Arc::new(gauge::Handle::new(key.to_owned(), None))
+    }
+
+    fn histogram(&self, key: &Key) -> Self::Histogram {
+        Arc::new(hist::Handle::new(key.to_owned(), None))
+    }
+}
+
+pub struct LogRecorder(Registry<Key, MetricStore>);
+
+impl Default for LogRecorder {
+    fn default() -> Self {
+        Self(Registry::new(MetricStore))
+    }
+}
+
+impl metrics::Recorder for LogRecorder {
+    fn describe_gauge(&self, key: KeyName, unit: Option<Unit>, _desc: SharedString) {
+        let key = Key::from_name(key);
+        let gauge = self.0.get_or_create_histogram(&key, |g| Arc::clone(g));
+        gauge.0.lock().unit = unit.unwrap_or(Unit::Count);
+    }
+
+    fn register_gauge(&self, key: &Key, _: &Metadata<'_>) -> Gauge {
+        let gauge = self.0.get_or_create_gauge(key, |g| Arc::clone(g));
+        Gauge::from_arc(gauge)
+    }
+
+    fn describe_counter(&self, key: KeyName, unit: Option<Unit>, _desc: SharedString) {
+        let key = Key::from_name(key);
+        let counter = self.0.get_or_create_histogram(&key, |c| Arc::clone(c));
+        counter.0.lock().unit = unit.unwrap_or(Unit::Count);
+    }
+
+    fn register_counter(&self, key: &Key, _: &Metadata<'_>) -> Counter {
+        let counter = self.0.get_or_create_counter(key, |c| Arc::clone(c));
+        Counter::from_arc(counter)
+    }
+
+    fn describe_histogram(&self, key: KeyName, unit: Option<Unit>, _desc: SharedString) {
+        let key = Key::from_name(key);
+        let hist = self.0.get_or_create_histogram(&key, |h| Arc::clone(h));
+        hist.0.lock().unit = unit.unwrap_or(Unit::Count);
+    }
+
+    fn register_histogram(&self, key: &Key, _: &Metadata<'_>) -> Histogram {
+        let hist = self.0.get_or_create_histogram(key, |h| Arc::clone(h));
+        Histogram::from_arc(hist)
+    }
+}

--- a/src/metrics/log_recorder.rs
+++ b/src/metrics/log_recorder.rs
@@ -36,34 +36,34 @@ impl Default for LogRecorder {
 impl metrics::Recorder for LogRecorder {
     fn describe_gauge(&self, key: KeyName, unit: Option<Unit>, _desc: SharedString) {
         let key = Key::from_name(key);
-        let gauge = self.0.get_or_create_histogram(&key, |g| Arc::clone(g));
+        let gauge = self.0.get_or_create_histogram(&key, Arc::clone);
         gauge.0.lock().unit = unit.unwrap_or(Unit::Count);
     }
 
     fn register_gauge(&self, key: &Key, _: &Metadata<'_>) -> Gauge {
-        let gauge = self.0.get_or_create_gauge(key, |g| Arc::clone(g));
+        let gauge = self.0.get_or_create_gauge(key, Arc::clone);
         Gauge::from_arc(gauge)
     }
 
     fn describe_counter(&self, key: KeyName, unit: Option<Unit>, _desc: SharedString) {
         let key = Key::from_name(key);
-        let counter = self.0.get_or_create_histogram(&key, |c| Arc::clone(c));
+        let counter = self.0.get_or_create_histogram(&key, Arc::clone);
         counter.0.lock().unit = unit.unwrap_or(Unit::Count);
     }
 
     fn register_counter(&self, key: &Key, _: &Metadata<'_>) -> Counter {
-        let counter = self.0.get_or_create_counter(key, |c| Arc::clone(c));
+        let counter = self.0.get_or_create_counter(key, Arc::clone);
         Counter::from_arc(counter)
     }
 
     fn describe_histogram(&self, key: KeyName, unit: Option<Unit>, _desc: SharedString) {
         let key = Key::from_name(key);
-        let hist = self.0.get_or_create_histogram(&key, |h| Arc::clone(h));
+        let hist = self.0.get_or_create_histogram(&key, Arc::clone);
         hist.0.lock().unit = unit.unwrap_or(Unit::Count);
     }
 
     fn register_histogram(&self, key: &Key, _: &Metadata<'_>) -> Histogram {
-        let hist = self.0.get_or_create_histogram(key, |h| Arc::clone(h));
+        let hist = self.0.get_or_create_histogram(key, Arc::clone);
         Histogram::from_arc(hist)
     }
 }

--- a/src/metrics/mod.rs
+++ b/src/metrics/mod.rs
@@ -1,0 +1,31 @@
+//! All of our wrappers and helpers for the `metrics` crate
+
+use metrics::Key;
+use parking_lot::Mutex;
+use tracing::Level;
+
+// Re-exports from the actual `metrics` crate
+pub use metrics::{describe_histogram, histogram, set_global_recorder, Unit};
+
+mod counter;
+mod gauge;
+mod hist;
+mod log_recorder;
+
+pub use hist::Tag as HistTag;
+pub use log_recorder::LogRecorder;
+
+const SPAN_LEVEL: Level = Level::INFO;
+
+struct Metric<T> {
+    key: Key,
+    unit: Unit,
+    value: T,
+}
+
+impl<T> Metric<T> {
+    fn new(key: Key, value: T, unit: Option<Unit>) -> Mutex<Self> {
+        let unit = unit.unwrap_or(Unit::Count);
+        Mutex::new(Metric { key, unit, value })
+    }
+}

--- a/src/opts/config.rs
+++ b/src/opts/config.rs
@@ -74,6 +74,19 @@ pub struct KeybindingsSection {
     pub extra: Option<Keybindings>,
 }
 
+#[derive(Deserialize, Clone, Debug, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub enum MetricsExporter {
+    Log,
+    Tcp,
+}
+
+#[derive(Deserialize, Clone, Debug, Default, PartialEq)]
+#[serde(default)]
+pub struct DebugSection {
+    pub metrics: Option<MetricsExporter>,
+}
+
 #[derive(Deserialize, Debug, Default, PartialEq)]
 #[serde(default, rename_all = "kebab-case")]
 pub struct Config {
@@ -85,6 +98,7 @@ pub struct Config {
     pub dark_theme: Option<OptionalTheme>,
     pub font_options: Option<FontOptions>,
     pub keybindings: KeybindingsSection,
+    pub debug: DebugSection,
 }
 
 impl Config {

--- a/src/opts/config.rs
+++ b/src/opts/config.rs
@@ -78,6 +78,7 @@ pub struct KeybindingsSection {
 #[serde(rename_all = "kebab-case")]
 pub enum MetricsExporter {
     Log,
+    #[cfg(inlyne_tcp_metrics)]
     Tcp,
 }
 

--- a/src/opts/mod.rs
+++ b/src/opts/mod.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 
 use crate::color;
 pub use cli::{Cli, Commands, ConfigCmd, ThemeType, View};
-pub use config::{Config, FontOptions, KeybindingsSection};
+pub use config::{Config, DebugSection, FontOptions, KeybindingsSection, MetricsExporter};
 
 use crate::history::History;
 use anyhow::Result;
@@ -51,6 +51,7 @@ pub struct Opts {
     pub font_opts: FontOptions,
     pub keybindings: KeybindingsSection,
     pub color_scheme: Option<ResolvedTheme>,
+    pub metrics: Option<MetricsExporter>,
 }
 
 impl Opts {
@@ -91,6 +92,7 @@ impl Opts {
             dark_theme,
             font_options,
             keybindings,
+            debug,
         } = config;
 
         let View {
@@ -100,6 +102,8 @@ impl Opts {
             config: _,
             page_width: args_page_width,
         } = args;
+
+        let DebugSection { metrics } = debug;
 
         let resolved_theme = args_theme
             .or(config_theme)
@@ -131,6 +135,7 @@ impl Opts {
             font_opts,
             keybindings,
             color_scheme: resolved_theme,
+            metrics,
         })
     }
 

--- a/src/opts/tests/parse.rs
+++ b/src/opts/tests/parse.rs
@@ -28,6 +28,7 @@ impl Opts {
             lines_to_scroll: LinesToScroll::default().0,
             keybindings: Default::default(),
             color_scheme: None,
+            metrics: Default::default(),
         }
     }
 }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -1,9 +1,11 @@
 use std::borrow::Cow;
 use std::sync::{Arc, Mutex};
+use std::time::Instant;
 
 use crate::color::{native_color, Theme};
 use crate::fonts::get_fonts;
 use crate::image::ImageRenderer;
+use crate::metrics::{histogram, HistTag};
 use crate::opts::FontOptions;
 use crate::positioner::{Positioned, Positioner, DEFAULT_MARGIN};
 use crate::table::TABLE_ROW_GAP;
@@ -828,8 +830,12 @@ impl Renderer {
     }
 
     pub fn reposition(&mut self, elements: &mut [Positioned<Element>]) -> anyhow::Result<()> {
-        self.positioner
-            .reposition(&mut self.text_system, elements, self.zoom)
+        let start = Instant::now();
+        let res = self
+            .positioner
+            .reposition(&mut self.text_system, elements, self.zoom);
+        histogram!(HistTag::Reposition).record(start.elapsed());
+        res
     }
 
     pub fn set_scroll_y(&mut self, scroll_y: f32) {


### PR DESCRIPTION
This adds something that I've been wanting implemented for a while. Metrics recording and emission :tada:

There's a new section in the config file that sets the metrics recorder

```toml
[debug]
metrics = "log"
metrics = "tcp"
```

It's unset by default which uses the noop recorder (aka as cheap as it can get)

## Log Recorder

(this one took a bit of work since it implements a recorder from "scratch")

When it's set to `"log"` the metrics start getting recorded as tracing events with some metadata attached on the span. This makes it possible to filter things pretty dynamically, and is accessible as a user doesn't need to download anything else to see the values

![image](https://github.com/Inlyne-Project/inlyne/assets/30302768/04f3a794-92f0-45fd-8ed6-67e2aea7ecab)

## TCP Recorder

When it's set to `"tcp"` the metrics get emitted following the default [`metrics-exporter-tcp`](https://docs.rs/metrics-exporter-tcp/0.9.0/metrics_exporter_tcp/) configuration. This means that anything that knows how to consume that can handle displaying the data live. Currently the only main program I know of is the [`metrics-observer`](https://crates.io/crates/metrics-observer) binary crate, but it's unfortunately a bit limited

https://github.com/Inlyne-Project/inlyne/assets/30302768/d1f684e0-30cd-49e1-a0c5-d32dd7d2fe99

