### PR TITLE
chore: Add a `.desktop` file

### DIFF
--- a/assets/inlyne.desktop
+++ b/assets/inlyne.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Name=Inlyne
+GenericName=Markdown Viewer
+Exec=inlyne %f
+Type=Application
+StartupWMClass=inlyne
+MimeType=text/markdown;
+Categories=Office;Viewer;
+Keywords=Markdown;Viewer;
+Terminal=false
+Comment=a GPU powered, browserless, markdown + html viewer


### PR DESCRIPTION
Adds a `.desktop` entry originally inspired by this comment https://github.com/Inlyne-Project/inlyne/issues/262#issuecomment-2025324280

Some simple testing on Pop OS seems to indicate that this works (`xdg-open` and different launchers appear to pick it up after adding the entry to ~/.local/share/applications/` and running `update-desktop-database ~/.local/share/applications`)