### PR TITLE
feat: use relative font size for headers

### DIFF
--- a/src/interpreter/html/mod.rs
+++ b/src/interpreter/html/mod.rs
@@ -43,14 +43,15 @@ pub enum HeaderType {
 }
 
 impl HeaderType {
-    pub fn text_size(&self) -> f32 {
-        match &self {
-            Self::H1 => 32.,
-            Self::H2 => 24.,
-            Self::H3 => 18.72,
-            Self::H4 => 16.,
-            Self::H5 => 13.28,
-            Self::H6 => 10.72,
+    // https://html.spec.whatwg.org/multipage/rendering.html#sections-and-headings
+    pub fn size_multiplier(&self) -> f32 {
+        match self {
+            HeaderType::H1 => 2.0,
+            HeaderType::H2 => 1.5,
+            HeaderType::H3 => 1.17,
+            HeaderType::H4 => 1.0,
+            HeaderType::H5 => 0.83,
+            HeaderType::H6 => 0.67,
         }
     }
 }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -848,7 +848,7 @@ impl HtmlInterpreter {
             }
             for elem in self.state.element_stack.iter().rev() {
                 if let InterpreterElement::Header(header) = elem {
-                    self.current_textbox.font_size = header.ty.text_size();
+                    self.current_textbox.font_size *= header.ty.size_multiplier();
                     text = text.make_bold(true);
                     break;
                 }


### PR DESCRIPTION
This closes #201.
I've chosen the header sizes of the HTML spec, as that seemed reasonable.

This doesn't change the appearance of the application
Relative / Static
![Screenshot_2024-04-11-20-48-21_5120x1263](https://github.com/Inlyne-Project/inlyne/assets/72217393/49a37f49-1a1c-4573-8451-c80079a13153)
