### PR TITLE
feat: add debug boxes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ keywords = ["markdown", "viewer", "gpu"]
 default = ["wayland", "x11"]
 x11 = ["copypasta/x11", "winit/x11"]
 wayland = ["copypasta/wayland", "winit/wayland"]
+debug = []
 
 [dependencies]
 winit = { version = "0.28.7", default-features = false }

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -541,8 +541,7 @@ impl Renderer {
                     .clone();
                 rect.pos.1 -= self.scroll_y;
                 let color = glyphon::Color::rgb(255, 0, 255).0;
-                let _ =
-                    self.stroke_rectangle(rect, native_color(color, &self.surface_format), 1.0);
+                let _ = self.stroke_rectangle(rect, native_color(color, &self.surface_format), 1.0);
             }
         }
 

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -532,6 +532,18 @@ impl Renderer {
                     }
                 }
             }
+            #[cfg(feature = "debug")]
+            {
+                let mut rect = element
+                    .bounds
+                    .as_ref()
+                    .context("Element not positioned")?
+                    .clone();
+                rect.pos.1 -= self.scroll_y;
+                let color = glyphon::Color::rgb(255, 0, 255).0;
+                let _ =
+                    self.stroke_rectangle(rect, native_color(color, &self.surface_format), 1.0);
+            }
         }
 
         self.draw_scrollbar()?;


### PR DESCRIPTION
This adds bounding boxes to elements when the `debug` flag is used, as mentioned in https://github.com/Inlyne-Project/inlyne/issues/294#issuecomment-2050745847
![Screenshot_2024-04-12-12-43-38_5120x1263](https://github.com/Inlyne-Project/inlyne/assets/72217393/1fdb497c-0353-4b53-834d-e015c83fdcb1)
![Screenshot_2024-04-12-12-44-23_5120x1263](https://github.com/Inlyne-Project/inlyne/assets/72217393/4b918e65-06c8-427d-a181-b9474a31af9d)
