### PR TITLE
refactor: Move element bound render toggle to config

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ keywords = ["markdown", "viewer", "gpu"]
 default = ["wayland", "x11"]
 x11 = ["copypasta/x11", "winit/x11"]
 wayland = ["copypasta/wayland", "winit/wayland"]
-debug = []
 
 [dependencies]
 winit = { version = "0.28.7", default-features = false }

--- a/src/opts/config.rs
+++ b/src/opts/config.rs
@@ -83,9 +83,10 @@ pub enum MetricsExporter {
 }
 
 #[derive(Deserialize, Clone, Debug, Default, PartialEq)]
-#[serde(default)]
+#[serde(default, rename_all = "kebab-case")]
 pub struct DebugSection {
     pub metrics: Option<MetricsExporter>,
+    pub render_element_bounds: bool,
 }
 
 #[derive(Deserialize, Clone, Debug, PartialEq)]

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -524,8 +524,8 @@ impl Renderer {
                     }
                 }
             }
-            #[cfg(feature = "debug")]
-            {
+
+            if crate::opts::get_render_element_bounds() {
                 let mut rect = element
                     .bounds
                     .as_ref()


### PR DESCRIPTION
Moves the render element bound toggle to a config value under the debug section aka

```toml
[debug]
render-element-bounds = false
```