### PR TITLE
Sanity check CI being garbo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,5 @@
+# Everything is hanging ;-;
+
 [workspace]
 members = [
     ".",


### PR DESCRIPTION
Looks like windows CI is deciding to hang on the end of the test suite for no reason