### PR TITLE
Windows CI is hanging

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -53,8 +53,8 @@ jobs:
       - name: Cache
         uses: Swatinem/rust-cache@v2
 
-      - name: Linting
-        run: cargo clippy --workspace --no-default-features --features x11 -- --deny warnings
+      # - name: Linting
+      #   run: cargo clippy --workspace --no-default-features --features x11 -- --deny warnings
 
   build-macos-arm:
     runs-on: macos-latest


### PR DESCRIPTION
Looks like windows CI has gotten in the habit of hanging with the test suite. Time to see if it's a new problem with us or a new problem with GH