### PR TITLE
fix: Dont panic on missing file path

### DIFF
--- a/src/history.rs
+++ b/src/history.rs
@@ -1,5 +1,7 @@
 use std::path::{Path, PathBuf};
 
+use anyhow::Context;
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct History {
     history: Vec<PathBuf>,
@@ -7,12 +9,14 @@ pub struct History {
 }
 
 impl History {
-    pub fn new(path: &Path) -> Self {
-        let canonicalized = path.canonicalize().unwrap();
-        Self {
+    pub fn new(path: &Path) -> anyhow::Result<Self> {
+        let canonicalized = path
+            .canonicalize()
+            .with_context(|| format!("Unable to canonicalize {}", path.display()))?;
+        Ok(Self {
             history: vec![canonicalized],
             index: 0,
-        }
+        })
     }
 
     pub fn get_path(&self) -> &Path {
@@ -71,7 +75,7 @@ mod tests {
         fs::write(&fork1, "b").unwrap();
         fs::write(&fork2, "c").unwrap();
 
-        let mut hist = History::new(&root);
+        let mut hist = History::new(&root).unwrap();
         assert_eq!(hist.get_path(), root);
         assert_eq!(hist.previous(), None);
 

--- a/src/opts/mod.rs
+++ b/src/opts/mod.rs
@@ -129,6 +129,7 @@ impl Opts {
 
         set_render_element_bounds(render_element_bounds);
 
+        let history = History::new(&file_path)?;
         let resolved_theme = args_theme
             .or(config_theme)
             .and_then(ResolvedTheme::new)
@@ -157,7 +158,7 @@ impl Opts {
         };
 
         Ok(Self {
-            history: History::new(&file_path),
+            history,
             theme,
             scale,
             page_width,

--- a/src/opts/tests/parse.rs
+++ b/src/opts/tests/parse.rs
@@ -31,7 +31,7 @@ fn temp_md_file() -> (NamedTempFile, String) {
 impl Opts {
     fn mostly_default(file_path: impl AsRef<Path>) -> Self {
         Self {
-            history: History::new(file_path.as_ref()),
+            history: History::new(file_path.as_ref()).unwrap(),
             theme: ResolvedTheme::Light.as_theme(),
             scale: None,
             page_width: None,


### PR DESCRIPTION
Fixes so that we no longer panic when passing `inlyne` a file path that doesn't exist again