### PR TITLE
deps: Update svenstaro/upload-release-action to 2.9.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
         fi
 
     - name: Upload binaries to release
-      uses: svenstaro/upload-release-action@v1-release
+      uses: svenstaro/upload-release-action@2.9.0
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
         file: ${{ env.ASSET }}


### PR DESCRIPTION
Please end my GH suffering. This is my best guess at this point as to why the release pipeline is failing despite no workflow/organization/repo changes. Specifically this warning

```
The following actions use a deprecated Node.js version and will be forced to run on node20: actions/checkout@v3, svenstaro/upload-release-action@v1-release. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
```

_:sparkles:Lovely:sparkles:..._