### PR TITLE
release: Update version to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1877,7 +1877,7 @@ dependencies = [
 
 [[package]]
 name = "inlyne"
-version = "0.5.0-dev"
+version = "0.5.0"
 dependencies = [
  "anstream",
  "anstyle",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ members = [
 
 [package]
 name = "inlyne"
-version = "0.5.0-dev"
+version = "0.5.0"
 description = "Introducing Inlyne, a GPU powered yet browserless tool to help you quickly view markdown files in the blink of an eye."
 edition = "2021"
 authors = [

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -989,5 +989,5 @@ fn custom_user_agent() {
     let server::FromServer::UserAgent(Some(user_agent)) = recv_ua.recv().unwrap() else {
         panic!();
     };
-    insta::assert_snapshot!(user_agent, @"inlyne 0.5.0-dev https://github.com/Inlyne-Project/inlyne");
+    insta::assert_snapshot!(user_agent, @"inlyne 0.5.0 https://github.com/Inlyne-Project/inlyne");
 }

--- a/src/panic_hook.rs
+++ b/src/panic_hook.rs
@@ -221,12 +221,12 @@ mod tests {
         let report_path = report.persist().unwrap();
 
         let contents = std::fs::read_to_string(&report_path).unwrap();
-        insta::assert_snapshot!(contents, @r###"
+        insta::assert_snapshot!(contents, @r"
         # Crash Report
 
         | Name | `inlyne` |
         | ---: | :--- |
-        | Version | `0.5.0-dev` |
+        | Version | `0.5.0` |
         | Operating System | [REDACTED] |
 
         `````text
@@ -248,6 +248,6 @@ mod tests {
         ---
 
         <!-- Add any relevant info below vv -->
-        "###);
+        ");
     }
 }


### PR DESCRIPTION
After this is merged I'll be pushing a tag to trigger the release workflow and then assuming that works without issue (which it hasn't for the past few releases :upside_down_face:) I'll be publishing the new release on crates and GH