### PR TITLE
Make window decorations optional and use a better CSD on Wayland

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,22 @@
 version = 3
 
 [[package]]
+name = "ab_glyph"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec3672c180e71eeaaac3a541fbbc5f5ad4def8b747c595ad30d674e43049f7b0"
+dependencies = [
+ "ab_glyph_rasterizer",
+ "owned_ttf_parser",
+]
+
+[[package]]
+name = "ab_glyph_rasterizer"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71b1793ee61086797f5c80b6efa2b8ffa6d5dd703f118545808a7f2e27f7046"
+
+[[package]]
 name = "addr2line"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2972,6 +2988,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
+name = "owned_ttf_parser"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ec719bbf3b2a81c109a4e20b1f129b5566b7dce654bc3872f6a05abf82b2c4"
+dependencies = [
+ "ttf-parser 0.25.1",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3575,7 +3600,7 @@ dependencies = [
  "png",
  "rgb",
  "svgtypes",
- "tiny-skia",
+ "tiny-skia 0.11.4",
  "usvg",
 ]
 
@@ -3747,6 +3772,19 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sctk-adwaita"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda4e97be1fd174ccc2aae81c8b694e803fa99b34e8fd0f057a9d70698e3ed09"
+dependencies = [
+ "ab_glyph",
+ "log",
+ "memmap2 0.5.10",
+ "smithay-client-toolkit 0.16.1",
+ "tiny-skia 0.8.4",
+]
 
 [[package]]
 name = "serde"
@@ -4340,6 +4378,20 @@ dependencies = [
 
 [[package]]
 name = "tiny-skia"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8493a203431061e901613751931f047d1971337153f96d0e5e363d6dbf6a67"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "bytemuck",
+ "cfg-if",
+ "png",
+ "tiny-skia-path 0.8.4",
+]
+
+[[package]]
+name = "tiny-skia"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83d13394d44dae3207b52a326c0c85a8bf87f1541f23b0d143811088497b09ab"
@@ -4350,7 +4402,18 @@ dependencies = [
  "cfg-if",
  "log",
  "png",
- "tiny-skia-path",
+ "tiny-skia-path 0.11.4",
+]
+
+[[package]]
+name = "tiny-skia-path"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adbfb5d3f3dd57a0e11d12f4f13d4ebbbc1b5c15b7ab0a156d030b21da5f677c"
+dependencies = [
+ "arrayref",
+ "bytemuck",
+ "strict-num",
 ]
 
 [[package]]
@@ -4518,6 +4581,12 @@ name = "ttf-parser"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17f77d76d837a7830fe1d4f12b7b4ba4192c1888001c7164257e4bc6d21d96b4"
+
+[[package]]
+name = "ttf-parser"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
 
 [[package]]
 name = "two-face"
@@ -4710,7 +4779,7 @@ dependencies = [
  "siphasher 0.3.11",
  "strict-num",
  "svgtypes",
- "tiny-skia-path",
+ "tiny-skia-path 0.11.4",
  "unicode-bidi",
  "unicode-script",
  "unicode-vo",
@@ -5039,6 +5108,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be12ce1a3c39ec7dba25594b97b42cb3195d54953ddb9d3d95a7c3902bc6e9d4"
 dependencies = [
  "dlib",
+ "lazy_static",
  "pkg-config",
 ]
 
@@ -5474,6 +5544,7 @@ dependencies = [
  "percent-encoding",
  "raw-window-handle",
  "redox_syscall 0.3.5",
+ "sctk-adwaita",
  "smithay-client-toolkit 0.16.1",
  "wasm-bindgen",
  "wayland-client 0.29.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ categories = ["gui"]
 [features]
 default = ["wayland", "x11"]
 x11 = ["copypasta/x11", "winit/x11"]
-wayland = ["copypasta/wayland", "winit/wayland"]
+wayland = ["copypasta/wayland", "winit/wayland", "winit/wayland-csd-adwaita"]
 
 [dependencies]
 # `anstream` and `anstyle` are both terminal helper crates used for our custom

--- a/src/main.rs
+++ b/src/main.rs
@@ -163,6 +163,9 @@ impl Inlyne {
         let window = {
             let mut wb = WindowBuilder::new().with_title(utils::format_title(&file_path));
 
+            if let Some(decorations) = opts.decorations {
+                wb = wb.with_decorations(decorations);
+            }
             if let Some(ref pos) = opts.position {
                 wb = wb.with_position(winit::dpi::PhysicalPosition::new(pos.x, pos.y));
             }

--- a/src/opts/cli.rs
+++ b/src/opts/cli.rs
@@ -129,6 +129,10 @@ pub struct View {
     #[arg(short = 't', long = "theme", value_parser = value_parser!(ThemeType))]
     pub theme: Option<ThemeType>,
 
+    /// Enable decorations
+    #[arg(short = 'd', long = "decorations")]
+    pub decorations: Option<bool>,
+
     /// Factor to scale rendered file by [default: OS defined window scale factor]
     #[arg(short = 's', long = "scale")]
     pub scale: Option<f32>,

--- a/src/opts/config.rs
+++ b/src/opts/config.rs
@@ -99,6 +99,7 @@ pub struct Window {
 #[serde(default, rename_all = "kebab-case")]
 pub struct Config {
     pub theme: Option<ThemeType>,
+    pub decorations: Option<bool>,
     pub scale: Option<f32>,
     pub page_width: Option<f32>,
     pub lines_to_scroll: LinesToScroll,

--- a/src/opts/mod.rs
+++ b/src/opts/mod.rs
@@ -59,6 +59,7 @@ pub struct Opts {
     pub history: History,
     #[debug(skip)]
     pub theme: color::Theme,
+    pub decorations: Option<bool>,
     pub scale: Option<f32>,
     pub page_width: Option<f32>,
     pub lines_to_scroll: f32,
@@ -101,6 +102,7 @@ impl Opts {
     ) -> Result<Self> {
         let Config {
             theme: config_theme,
+            decorations: config_decorations,
             scale: config_scale,
             page_width: config_page_width,
             lines_to_scroll,
@@ -115,6 +117,7 @@ impl Opts {
         let View {
             file_path,
             theme: args_theme,
+            decorations,
             scale: args_scale,
             config: _,
             page_width: args_page_width,
@@ -146,6 +149,7 @@ impl Opts {
             }
         };
 
+        let decorations = decorations.or(config_decorations);
         let scale = args_scale.or(config_scale);
         let font_opts = font_options.unwrap_or_default();
         let page_width = args_page_width.or(config_page_width);
@@ -160,6 +164,7 @@ impl Opts {
         Ok(Self {
             history,
             theme,
+            decorations,
             scale,
             page_width,
             lines_to_scroll,

--- a/src/opts/tests/parse.rs
+++ b/src/opts/tests/parse.rs
@@ -33,6 +33,7 @@ impl Opts {
         Self {
             history: History::new(file_path.as_ref()).unwrap(),
             theme: ResolvedTheme::Light.as_theme(),
+            decorations: None,
             scale: None,
             page_width: None,
             font_opts: FontOptions::default(),


### PR DESCRIPTION
This PR lets you pass the `-d` or `--decorations` boolean argument to enable/disable decorations, and enables winit's sctk-adwaita CSDs for Wayland compositors that don't use SSDs.

| prev (ugly) | this PR (CSD) | no decorations |
|-------------|---------------|----------------|
| ![image](https://github.com/user-attachments/assets/35bfc430-8409-47ff-99ab-8dac4a23fc93) | ![image](https://github.com/user-attachments/assets/aad42695-e6c0-4457-9a02-13254217f69d) | ![image](https://github.com/user-attachments/assets/7e048652-b721-4953-a313-800157449581) |