### PR TITLE
refactor: `std::sync::Mutex` -> `parking_lot::Mutex`

### DIFF
--- a/src/interpreter/snapshots/inlyne__interpreter__tests__image_loading_fails_gracefully.snap
+++ b/src/interpreter/snapshots/inlyne__interpreter__tests__image_loading_fails_gracefully.snap
@@ -1,6 +1,6 @@
 ---
 source: src/interpreter/tests.rs
-description: "![This actually returns JSON 😈](http://127.0.0.1:38947/snapshot.png)"
+description: "![This actually returns JSON 😈](http://127.0.0.1:37929/2/snapshot.png)"
 expression: "interpret_md_with_opts(&text, opts)"
 ---
 [
@@ -21,8 +21,6 @@ expression: "interpret_md_with_opts(&text, opts)"
                                         dimensions: (63, 72),
                                     },
                                 ),
-                                poisoned: false,
-                                ..
                             },
                             is_aligned: Some(Left),
                             ..

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -1,5 +1,5 @@
 use std::borrow::Cow;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use std::time::Instant;
 
 use crate::color::{native_color, Theme};
@@ -21,6 +21,7 @@ use lyon::geom::euclid::Point2D;
 use lyon::geom::Box2D;
 use lyon::path::Polygon;
 use lyon::tessellation::*;
+use parking_lot::Mutex;
 use wgpu::util::DeviceExt;
 use wgpu::{BindGroup, Buffer, IndexFormat, MultisampleState, TextureFormat};
 use winit::window::Window;
@@ -771,7 +772,7 @@ impl Renderer {
         let image_bindgroups = self.image_bindgroups(elements);
 
         {
-            let mut text_cache = self.text_system.text_cache.lock().unwrap();
+            let mut text_cache = self.text_system.text_cache.lock();
             let text_areas: Vec<TextArea> = cached_text_areas
                 .iter()
                 .map(|c| c.text_area(&text_cache))
@@ -780,7 +781,7 @@ impl Renderer {
             self.text_system.text_renderer.prepare(
                 &self.device,
                 &self.queue,
-                &mut self.text_system.font_system.lock().unwrap(),
+                &mut self.text_system.font_system.lock(),
                 &mut self.text_system.text_atlas,
                 Resolution {
                     width: self.config.width,

--- a/src/text.rs
+++ b/src/text.rs
@@ -3,13 +3,14 @@ use std::collections::hash_map;
 use std::fmt;
 use std::hash::{BuildHasher, Hash, Hasher};
 use std::ops::Range;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use fxhash::{FxHashMap, FxHashSet};
 use glyphon::{
     Affinity, Attrs, AttrsList, BufferLine, Color, Cursor, FamilyOwned, FontSystem, LayoutGlyph,
     Shaping, Style, SwashCache, TextArea, TextBounds, Weight,
 };
+use parking_lot::Mutex;
 use smart_debug::SmartDebug;
 use taffy::prelude::{AvailableSpace, Size as TaffySize};
 
@@ -201,10 +202,10 @@ impl TextBox {
             return None;
         }
 
-        let mut cache = text_system.text_cache.lock().unwrap();
+        let mut cache = text_system.text_cache.lock();
 
         let (_, buffer) = cache.allocate(
-            text_system.font_system.lock().unwrap().borrow_mut(),
+            text_system.font_system.lock().borrow_mut(),
             self.key(bounds, zoom),
         );
 
@@ -241,14 +242,12 @@ impl TextBox {
             return (0., self.padding_height * self.hidpi_scale * zoom);
         }
 
-        let mut cache = text_cache.lock().unwrap();
+        let mut cache = text_cache.lock();
 
         let line_height = self.line_height(zoom);
 
-        let (_, paragraph) = cache.allocate(
-            font_system.lock().unwrap().borrow_mut(),
-            self.key(bounds, zoom),
-        );
+        let (_, paragraph) =
+            cache.allocate(font_system.lock().borrow_mut(), self.key(bounds, zoom));
 
         let (total_lines, max_width) = paragraph
             .layout_runs()
@@ -274,9 +273,9 @@ impl TextBox {
         let cache = text_system.text_cache.borrow_mut();
 
         let (key, max_width) = {
-            let mut cache = cache.lock().unwrap();
+            let mut cache = cache.lock();
             let (key, paragraph) = cache.allocate(
-                text_system.font_system.lock().unwrap().borrow_mut(),
+                text_system.font_system.lock().borrow_mut(),
                 self.key(bounds, zoom),
             );
 
@@ -341,10 +340,10 @@ impl TextBox {
         let line_height = self.line_height(zoom);
         let mut lines = Vec::new();
 
-        let mut cache = text_system.text_cache.lock().unwrap();
+        let mut cache = text_system.text_cache.lock();
 
         let (_, buffer) = cache.allocate(
-            text_system.font_system.lock().unwrap().borrow_mut(),
+            text_system.font_system.lock().borrow_mut(),
             self.key(bounds, zoom),
         );
 
@@ -420,10 +419,10 @@ impl TextBox {
         let mut selected_text = String::new();
 
         let line_height = self.line_height(zoom);
-        let mut cache = text_system.text_cache.lock().unwrap();
+        let mut cache = text_system.text_cache.lock();
 
         let (_, buffer) = cache.allocate(
-            text_system.font_system.lock().unwrap().borrow_mut(),
+            text_system.font_system.lock().borrow_mut(),
             self.key(bounds, zoom),
         );
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::io;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, OnceLock};
 
 use crate::image::ImageData;
 
@@ -9,6 +9,7 @@ use comrak::adapters::SyntaxHighlighterAdapter;
 use comrak::plugins::syntect::{SyntectAdapter, SyntectAdapterBuilder};
 use comrak::{markdown_to_html_with_plugins, ComrakOptions};
 use indexmap::IndexMap;
+use parking_lot::Mutex;
 use serde::Deserialize;
 use syntect::highlighting::{Theme as SyntectTheme, ThemeSet as SyntectThemeSet};
 use syntect::parsing::SyntaxSet;


### PR DESCRIPTION
This switches the behavior from panicking on poison errors to releasing the lock which shouldn't be a problem. If anything it's more correct