### PR TITLE
refactor: Treat table headers as bolded data cells

### DIFF
--- a/src/interpreter/html/element.rs
+++ b/src/interpreter/html/element.rs
@@ -53,12 +53,4 @@ impl Element {
             None
         }
     }
-
-    pub fn as_mut_table(&mut self) -> Option<&mut Table> {
-        if let Self::Table(table) = self {
-            Some(table)
-        } else {
-            None
-        }
-    }
 }

--- a/src/interpreter/mod.rs
+++ b/src/interpreter/mod.rs
@@ -635,11 +635,12 @@ impl HtmlInterpreter {
             TagName::Small => self.state.text_options.small -= 1,
             TagName::TableHead | TagName::TableBody => {}
             TagName::TableHeader => {
-                let iter = self.state.element_iter_mut();
-                let table = iter.rev().find_map(|elem| elem.as_mut_table()).unwrap();
-                table.push_header(self.current_textbox.clone());
+                let table_row = self.state.element_stack.last_mut();
+                if let Some(InterpreterElement::TableRow(ref mut row)) = table_row {
+                    self.state.text_options.bold -= 1;
+                    row.push(self.current_textbox.clone());
+                }
                 self.current_textbox.texts.clear();
-                self.state.text_options.bold -= 1;
             }
             TagName::TableDataCell => {
                 let table_row = self.state.element_stack.last_mut();

--- a/src/interpreter/snapshots/inlyne__interpreter__tests__aligned_table.snap
+++ b/src/interpreter/snapshots/inlyne__interpreter__tests__aligned_table.snap
@@ -9,66 +9,66 @@ expression: "interpret_md_with_opts(text, opts)"
     ),
     Table(
         Table {
-            headers: [
-                TextBox {
-                    texts: [
-                        Text {
-                            text: "left default",
-                            default_color: Color(BLACK),
-                            style: BOLD ,
-                            ..
-                        },
-                    ],
-                    ..
-                },
-                TextBox {
-                    texts: [
-                        Text {
-                            text: "left forced",
-                            default_color: Color(BLACK),
-                            style: BOLD ,
-                            ..
-                        },
-                    ],
-                    ..
-                },
-                TextBox {
-                    align: Center,
-                    texts: [
-                        Text {
-                            text: "centered",
-                            default_color: Color(BLACK),
-                            style: BOLD ,
-                            ..
-                        },
-                    ],
-                    ..
-                },
-                TextBox {
-                    align: Right,
-                    texts: [
-                        Text {
-                            text: "right",
-                            default_color: Color(BLACK),
-                            style: BOLD ,
-                            ..
-                        },
-                    ],
-                    ..
-                },
-                TextBox {
-                    texts: [
-                        Text {
-                            text: "left default",
-                            default_color: Color(BLACK),
-                            style: BOLD ,
-                            ..
-                        },
-                    ],
-                    ..
-                },
-            ],
             rows: [
+                [
+                    TextBox {
+                        texts: [
+                            Text {
+                                text: "left default",
+                                default_color: Color(BLACK),
+                                style: BOLD ,
+                                ..
+                            },
+                        ],
+                        ..
+                    },
+                    TextBox {
+                        texts: [
+                            Text {
+                                text: "left forced",
+                                default_color: Color(BLACK),
+                                style: BOLD ,
+                                ..
+                            },
+                        ],
+                        ..
+                    },
+                    TextBox {
+                        align: Center,
+                        texts: [
+                            Text {
+                                text: "centered",
+                                default_color: Color(BLACK),
+                                style: BOLD ,
+                                ..
+                            },
+                        ],
+                        ..
+                    },
+                    TextBox {
+                        align: Right,
+                        texts: [
+                            Text {
+                                text: "right",
+                                default_color: Color(BLACK),
+                                style: BOLD ,
+                                ..
+                            },
+                        ],
+                        ..
+                    },
+                    TextBox {
+                        texts: [
+                            Text {
+                                text: "left default",
+                                default_color: Color(BLACK),
+                                style: BOLD ,
+                                ..
+                            },
+                        ],
+                        ..
+                    },
+                ],
                 [
                     TextBox {
                         texts: [

--- a/src/interpreter/snapshots/inlyne__interpreter__tests__yaml_frontmatter.snap
+++ b/src/interpreter/snapshots/inlyne__interpreter__tests__yaml_frontmatter.snap
@@ -9,33 +9,33 @@ expression: "interpret_md_with_opts(text, opts)"
     ),
     Table(
         Table {
-            headers: [
-                TextBox {
-                    align: Center,
-                    texts: [
-                        Text {
-                            text: "date",
-                            default_color: Color(BLACK),
-                            style: BOLD ,
-                            ..
-                        },
-                    ],
-                    ..
-                },
-                TextBox {
-                    align: Center,
-                    texts: [
-                        Text {
-                            text: "tags",
-                            default_color: Color(BLACK),
-                            style: BOLD ,
-                            ..
-                        },
-                    ],
-                    ..
-                },
-            ],
             rows: [
+                [
+                    TextBox {
+                        align: Center,
+                        texts: [
+                            Text {
+                                text: "date",
+                                default_color: Color(BLACK),
+                                style: BOLD ,
+                                ..
+                            },
+                        ],
+                        ..
+                    },
+                    TextBox {
+                        align: Center,
+                        texts: [
+                            Text {
+                                text: "tags",
+                                default_color: Color(BLACK),
+                                style: BOLD ,
+                                ..
+                            },
+                        ],
+                        ..
+                    },
+                ],
                 [
                     TextBox {
                         align: Center,

--- a/src/renderer.rs
+++ b/src/renderer.rs
@@ -374,63 +374,6 @@ impl Renderer {
                         self.zoom,
                     )?;
 
-                    for (col, node) in layout.headers.iter().enumerate() {
-                        if let Some(text_box) = table.headers.get(col) {
-                            text_areas.push(text_box.text_areas(
-                                &mut self.text_system,
-                                (pos.0 + node.location.x, pos.1 + node.location.y),
-                                (node.size.width, f32::MAX),
-                                self.zoom,
-                                self.scroll_y,
-                            ));
-                            if let Some(selection_rects) = text_box.render_selection(
-                                &mut self.text_system,
-                                (pos.0 + node.location.x, pos.1 + node.location.y),
-                                (node.size.width, node.size.height),
-                                self.zoom,
-                                selection,
-                            ) {
-                                for rect in selection_rects {
-                                    self.draw_rectangle(
-                                        Rect::from_min_max(
-                                            (rect.pos.0, rect.pos.1 - self.scroll_y),
-                                            (rect.max().0, rect.max().1 - self.scroll_y),
-                                        ),
-                                        native_color(self.theme.select_color, &self.surface_format),
-                                    )?;
-                                }
-                            }
-                        }
-                    }
-                    let y = layout
-                        .headers
-                        .last()
-                        .map(|last_header_node| {
-                            last_header_node.location.y
-                                + last_header_node.size.height
-                                + TABLE_ROW_GAP / 2.0
-                        })
-                        .unwrap_or(0.0);
-                    let x = layout
-                        .headers
-                        .last()
-                        .map(|f| f.location.x + f.size.width)
-                        .unwrap_or(0.);
-                    {
-                        let min = (
-                            scrolled_pos.0.max(DEFAULT_MARGIN + centering),
-                            scrolled_pos.1 + y,
-                        );
-                        let max = (
-                            (scrolled_pos.0 + x),
-                            scrolled_pos.1 + y + 2. * self.hidpi_scale * self.zoom,
-                        );
-                        self.draw_rectangle(
-                            Rect::from_min_max(min, max),
-                            native_color(self.theme.text_color, &self.surface_format),
-                        )?;
-                    }
-
                     for (row, node_row) in layout.rows.iter().enumerate() {
                         for (col, node) in node_row.iter().enumerate() {
                             if let Some(row) = table.rows.get(row) {
@@ -466,7 +409,9 @@ impl Renderer {
                                 }
                             }
                         }
-                        let last_row_node = node_row.last().unwrap();
+                        let Some(last_row_node) = node_row.last() else {
+                            continue;
+                        };
                         let y = last_row_node.location.y
                             + last_row_node.size.height
                             + TABLE_ROW_GAP / 2.;


### PR DESCRIPTION
Split out from #318 

Table headers were special-cased for some reason. We get the same result for a lot less code if we treat headers like bolded data cells instead