### PR TITLE
fix: update metrics crate and remove unused import for rustc 1.94 compat

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2521,9 +2521,9 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.24.1"
+version = "0.24.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a7deb012b3b2767169ff203fadb4c6b0b82b947512e5eb9e0b78c2e186ad9e3"
+checksum = "5d5312e9ba3771cfa961b585728215e3d972c950a3eed9252aa093d6301277e8"
 dependencies = [
  "ahash",
  "portable-atomic",

--- a/src/opts/cli.rs
+++ b/src/opts/cli.rs
@@ -1,5 +1,5 @@
 use clap::{
-    builder::PossibleValue, command, value_parser, Args as ClapArgs, Parser, Subcommand, ValueEnum,
+    builder::PossibleValue, value_parser, Args as ClapArgs, Parser, Subcommand, ValueEnum,
 };
 use serde::Deserialize;
 use std::array;


### PR DESCRIPTION
## Summary

This PR fixes a build failure with rustc 1.94+ and removes an unused import warning.

## Changes

- **Cargo.lock**: Bump `metrics` from 0.24.1 to 0.24.3 to fix `E0521` (borrowed data escapes outside of associated function) caused by a recent compiler change that rejects raw pointer casts extending lifetimes on trait objects. See https://github.com/rust-lang/rust/issues/141402
- **src/opts/cli.rs**: Remove unused `command` import from `clap` (flagged as warning)

## Reproduction

Building with `rustc 1.94.0` fails with:


error[E0521]: borrowed data escapes outside of associated function
 --> metrics-0.24.0/src/recorder/mod.rs:156:13

Fixed by running:
bash
cargo update -p metrics
cargo fix --bin "inlyne" -p inlyne --allow-dirty