### PR TITLE
Add optional Mermaid rendering support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 /target
 /flamegraph.svg
+
+# RustRover / JetBrains IDE metadata
+/.idea/
+*.iml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -909,6 +909,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "core_maths"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "cosmic-text"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1359,6 +1368,20 @@ dependencies = [
  "slotmap",
  "tinyvec",
  "ttf-parser 0.20.0",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "memmap2 0.9.5",
+ "slotmap",
+ "tinyvec",
+ "ttf-parser 0.25.1",
 ]
 
 [[package]]
@@ -1993,6 +2016,7 @@ dependencies = [
  "insta",
  "lyon",
  "lz4_flex",
+ "mermaid-rs-renderer",
  "metrics",
  "metrics-exporter-tcp",
  "metrics-util",
@@ -2158,6 +2182,16 @@ checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "json5"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "733a844dbd6fef128e98cb4487b887cb55454d92cd9994b1bafe004fabbe670c"
+dependencies = [
+ "serde",
+ "ucd-trie",
 ]
 
 [[package]]
@@ -2503,6 +2537,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mermaid-rs-renderer"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b808a8c109e16ba5de1c829bd9326aea0a72c176174ddb681284f56579d892ac"
+dependencies = [
+ "anyhow",
+ "fontdb 0.23.0",
+ "json5",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.11",
+ "ttf-parser 0.25.1",
 ]
 
 [[package]]
@@ -3584,13 +3635,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.9",
+ "regex-automata 0.4.14",
  "regex-syntax 0.8.5",
 ]
 
@@ -3605,9 +3656,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4611,6 +4662,9 @@ name = "ttf-parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
+dependencies = [
+ "core_maths",
+]
 
 [[package]]
 name = "two-face"
@@ -4639,6 +4693,12 @@ name = "typed-arena"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "uds_windows"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ authors = [
 ]
 license = "MIT"
 repository = "https://github.com/Inlyne-Project/inlyne"
-rust-version = "1.81.0"
+rust-version = "1.85.0"
 exclude = [
     "/ci/*",
     "/.github/*",
@@ -27,6 +27,7 @@ categories = ["gui"]
 
 [features]
 default = ["wayland", "x11"]
+mermaid = ["dep:mermaid-rs-renderer"]
 x11 = ["copypasta/x11", "winit/x11"]
 wayland = ["copypasta/wayland", "winit/wayland", "winit/wayland-csd-adwaita"]
 
@@ -130,6 +131,12 @@ features = ["fontconfig"]
 [dependencies.indexmap]
 version = "2.7.1"
 features = ["serde"]
+
+# Browserless Mermaid rendering
+[dependencies.mermaid-rs-renderer]
+version = "0.2.2"
+default-features = false
+optional = true
 
 # Metrics helpers used for our custom metric logger
 [dependencies.metrics-util]

--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -82,6 +82,34 @@ impl ImageData {
         })
     }
 
+    pub fn load_svg(bytes: &[u8], hidpi_scale: f32) -> anyhow::Result<Self> {
+        let opt = usvg::Options::default();
+        let mut tree = usvg::Tree::from_data(bytes, &opt)?;
+        let scaled_size = tiny_skia::Size::from_wh(
+            tree.size.width() * hidpi_scale,
+            tree.size.height() * hidpi_scale,
+        )
+        .context("SVG image dimensions are invalid")?;
+        tree.size = tree.size.scale_to(scaled_size);
+
+        static FONTDB: OnceLock<fontdb::Database> = OnceLock::new();
+        let fontdb = FONTDB.get_or_init(|| {
+            let mut db = fontdb::Database::new();
+            db.load_system_fonts();
+            db
+        });
+        tree.postprocess(Default::default(), fontdb);
+
+        let mut pixmap =
+            tiny_skia::Pixmap::new(tree.size.width() as u32, tree.size.height() as u32)
+                .context("Couldn't create svg pixmap")?;
+        resvg::render(&tree, tiny_skia::Transform::default(), &mut pixmap.as_mut());
+
+        let image = ImageBuffer::from_raw(pixmap.width(), pixmap.height(), pixmap.data().into())
+            .context("Svg buffer has invalid dimensions")?;
+        Ok(ImageData::new(image, false))
+    }
+
     pub fn to_bytes(&self) -> Vec<u8> {
         decode::lz4_decompress(&self.lz4_blob, self.rgba_image_byte_size())
             .expect("Size matches and I/O is in memory")
@@ -279,47 +307,20 @@ impl Image {
 
             let image = if let Ok(image) = ImageData::load(&image_data, true) {
                 image
+            } else if let Ok(image) = ImageData::load_svg(&image_data, hidpi_scale) {
+                image
             } else {
-                let opt = usvg::Options::default();
                 // TODO: yes all of this image loading is very messy and could use a refactor
-                let Ok(mut tree) = usvg::Tree::from_data(&image_data, &opt) else {
-                    tracing::warn!(
-                        "Failed loading image:\n- src: {}\n- src_path: {}",
-                        src,
-                        src_path.display()
-                    );
-                    let image =
-                        ImageData::load(include_bytes!("../../assets/img/broken.png"), false)
-                            .unwrap();
-                    *image_data_clone.lock() = Some(image);
-                    image_callback.loaded_image(src, image_data_clone);
-                    return;
-                };
-                tree.size = tree.size.scale_to(
-                    tiny_skia::Size::from_wh(
-                        tree.size.width() * hidpi_scale,
-                        tree.size.height() * hidpi_scale,
-                    )
-                    .unwrap(),
+                tracing::warn!(
+                    "Failed loading image:\n- src: {}\n- src_path: {}",
+                    src,
+                    src_path.display()
                 );
-                static FONTDB: OnceLock<fontdb::Database> = OnceLock::new();
-                let fontdb = FONTDB.get_or_init(|| {
-                    let mut db = fontdb::Database::new();
-                    db.load_system_fonts();
-                    db
-                });
-                tree.postprocess(Default::default(), fontdb);
-                let mut pixmap =
-                    tiny_skia::Pixmap::new(tree.size.width() as u32, tree.size.height() as u32)
-                        .context("Couldn't create svg pixmap")
-                        .unwrap();
-                resvg::render(&tree, tiny_skia::Transform::default(), &mut pixmap.as_mut());
-                ImageData::new(
-                    ImageBuffer::from_raw(pixmap.width(), pixmap.height(), pixmap.data().into())
-                        .context("Svg buffer has invalid dimensions")
-                        .unwrap(),
-                    false,
-                )
+                let image =
+                    ImageData::load(include_bytes!("../../assets/img/broken.png"), false).unwrap();
+                *image_data_clone.lock() = Some(image);
+                image_callback.loaded_image(src, image_data_clone);
+                return;
             };
 
             *image_data_clone.lock() = Some(image);

--- a/src/interpreter/ast.rs
+++ b/src/interpreter/ast.rs
@@ -1,4 +1,6 @@
 use crate::color::{native_color, Theme};
+#[cfg(feature = "mermaid")]
+use crate::image::ImageData;
 use crate::image::{Image, ImageSize};
 use crate::interpreter::hir::{Hir, HirNode, TextOrHirNode};
 use crate::interpreter::html::attr::PrefersColorScheme;
@@ -528,6 +530,24 @@ impl Process for FlowProcess {
             }
             TagName::PreformattedText => {
                 output.push_text_box(global, element, state.borrow());
+                #[cfg(feature = "mermaid")]
+                if let Some(source) = mermaid_source(global, node) {
+                    match render_mermaid_image(global, &source) {
+                        Ok(image) => {
+                            output.push_element(
+                                image.with_align(state.text_options.align.unwrap_or_default()),
+                            );
+                            output.push_spacer();
+                            return;
+                        }
+                        Err(err) => {
+                            tracing::warn!(
+                                "Failed rendering Mermaid diagram. Falling back to code block. Error: {err}"
+                            );
+                        }
+                    }
+                }
+
                 let style = attributes
                     .iter()
                     .find_map(|attr| attr.to_style())
@@ -617,6 +637,58 @@ impl Process for FlowProcess {
                         output,
                     );
                 }
+            }
+        }
+    }
+}
+
+#[cfg(feature = "mermaid")]
+fn render_mermaid_image(global: &Static, source: &str) -> anyhow::Result<Image> {
+    let svg = crate::mermaid::render_svg(source)?;
+    let image_data = ImageData::load_svg(svg.as_bytes(), global.opts.hidpi_scale)?;
+    Ok(Image::from_image_data(
+        Arc::new(Mutex::new(Some(image_data))),
+        global.opts.hidpi_scale,
+    ))
+}
+
+#[cfg(feature = "mermaid")]
+fn mermaid_source(global: &Static, node: &HirNode) -> Option<String> {
+    if has_mermaid_class(&node.attributes) {
+        return Some(collect_text_content(global, &node.content));
+    }
+
+    node.content.iter().find_map(|child| {
+        let TextOrHirNode::Hir(index) = child else {
+            return None;
+        };
+        let child = global.input.get(*index);
+        (child.tag == TagName::Code && has_mermaid_class(&child.attributes))
+            .then(|| collect_text_content(global, &child.content))
+    })
+}
+
+#[cfg(feature = "mermaid")]
+fn has_mermaid_class(attributes: &[Attr]) -> bool {
+    attributes
+        .iter()
+        .any(|attr| attr.has_class("mermaid") || attr.has_class("language-mermaid"))
+}
+
+#[cfg(feature = "mermaid")]
+fn collect_text_content(global: &Static, content: &[TextOrHirNode]) -> String {
+    let mut out = String::new();
+    collect_text_content_into(global, content, &mut out);
+    out
+}
+
+#[cfg(feature = "mermaid")]
+fn collect_text_content_into(global: &Static, content: &[TextOrHirNode], out: &mut String) {
+    for node in content {
+        match node {
+            TextOrHirNode::Text(text) => out.push_str(text),
+            TextOrHirNode::Hir(index) => {
+                collect_text_content_into(global, &global.input.get(*index).content, out)
             }
         }
     }

--- a/src/interpreter/html/attr.rs
+++ b/src/interpreter/html/attr.rs
@@ -24,6 +24,7 @@ impl Iterator for Iter<'_> {
                 local_name!("id") => Some(Attr::Anchor(format!("#{value}"))),
                 local_name!("width") => value.parse().ok().map(Attr::Width),
                 local_name!("height") => value.parse().ok().map(Attr::Height),
+                local_name!("class") => Some(Attr::Class(value.to_string())),
                 local_name!("src") => Some(Attr::Src(value.to_string())),
                 local_name!("start") => value.parse().ok().map(Attr::Start),
                 local_name!("style") => Some(Attr::Style(value.to_string())),
@@ -50,6 +51,8 @@ pub enum Attr {
     Anchor(String),
     Width(Px),
     Height(Px),
+    #[cfg_attr(not(feature = "mermaid"), allow(dead_code))]
+    Class(String),
     Src(String),
     Start(usize),
     Style(String),
@@ -79,6 +82,16 @@ impl Attr {
             Some(name.to_owned())
         } else {
             None
+        }
+    }
+    #[cfg_attr(not(feature = "mermaid"), allow(dead_code))]
+    pub fn has_class(&self, class_name: &str) -> bool {
+        if let Self::Class(classes) = self {
+            classes
+                .split_ascii_whitespace()
+                .any(|class| class == class_name)
+        } else {
+            false
         }
     }
 }

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -814,6 +814,62 @@ fn find_image(elements: &[Element]) -> Option<&Image> {
     })
 }
 
+const MERMAID_FLOWCHART: &str = "\
+```mermaid
+flowchart TD
+  A[Start] --> B[Done]
+```
+";
+
+#[cfg(feature = "mermaid")]
+const INVALID_MERMAID: &str = "\
+```mermaid
+this is not a mermaid diagram
+```
+";
+
+#[cfg(feature = "mermaid")]
+#[test]
+fn mermaid_code_block_renders_image() {
+    log::init();
+
+    let elems = interpret_md(MERMAID_FLOWCHART);
+    let image = find_image(&elems).expect("Mermaid code block should render as image");
+    let image_data = image.image_data.lock();
+    let image_data = image_data.as_ref().expect("Mermaid image data");
+    assert!(!image_data.to_bytes().is_empty());
+}
+
+#[cfg(feature = "mermaid")]
+#[test]
+fn invalid_mermaid_code_block_stays_readable() {
+    log::init();
+
+    let elems = interpret_md(INVALID_MERMAID);
+    assert!(find_image(&elems).is_none());
+    let code_blocks = elems
+        .iter()
+        .filter_map(elem_as_text_box)
+        .filter(|text_box| text_box.is_code_block)
+        .count();
+    assert_eq!(code_blocks, 1);
+}
+
+#[cfg(not(feature = "mermaid"))]
+#[test]
+fn mermaid_code_block_without_feature_stays_code_block() {
+    log::init();
+
+    let elems = interpret_md(MERMAID_FLOWCHART);
+    assert!(find_image(&elems).is_none());
+    let code_blocks = elems
+        .iter()
+        .filter_map(elem_as_text_box)
+        .filter(|text_box| text_box.is_code_block)
+        .count();
+    assert_eq!(code_blocks, 1);
+}
+
 #[test]
 fn centered_image_with_size_align_and_link() {
     log::init();

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,8 @@ pub mod history;
 pub mod image;
 pub mod interpreter;
 mod keybindings;
+#[cfg(feature = "mermaid")]
+mod mermaid;
 mod metrics;
 pub mod opts;
 mod panic_hook;

--- a/src/mermaid.rs
+++ b/src/mermaid.rs
@@ -1,0 +1,141 @@
+use std::sync::Mutex;
+
+pub fn render_svg(source: &str) -> anyhow::Result<String> {
+    match catch_renderer_unwind(|| render_svg_inner(source)) {
+        Ok(result) => result,
+        Err(payload) => {
+            anyhow::bail!("Mermaid renderer panicked: {}", panic_message(&*payload));
+        }
+    }
+}
+
+fn render_svg_inner(source: &str) -> anyhow::Result<String> {
+    let parsed = mermaid_rs_renderer::parse_mermaid(source)?;
+    if parsed.graph.kind == mermaid_rs_renderer::DiagramKind::Flowchart
+        && !has_explicit_flowchart_declaration(source)
+    {
+        anyhow::bail!("Mermaid flowchart is missing an explicit flowchart or graph declaration");
+    }
+
+    let theme = mermaid_rs_renderer::Theme::modern();
+    let layout_config = mermaid_rs_renderer::LayoutConfig::default();
+    let layout = mermaid_rs_renderer::compute_layout(&parsed.graph, &theme, &layout_config);
+    Ok(mermaid_rs_renderer::render_svg(
+        &layout,
+        &theme,
+        &layout_config,
+    ))
+}
+
+fn catch_renderer_unwind<T>(render: impl FnOnce() -> T) -> std::thread::Result<T> {
+    static PANIC_HOOK_LOCK: Mutex<()> = Mutex::new(());
+
+    let _guard = PANIC_HOOK_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    let previous_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(|_| {}));
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(render));
+    std::panic::set_hook(previous_hook);
+    result
+}
+
+fn panic_message(payload: &(dyn std::any::Any + Send)) -> &str {
+    if let Some(message) = payload.downcast_ref::<&'static str>() {
+        message
+    } else if let Some(message) = payload.downcast_ref::<String>() {
+        message
+    } else {
+        "unknown panic"
+    }
+}
+
+fn has_explicit_flowchart_declaration(source: &str) -> bool {
+    let Some(first_line) = first_diagram_line(source) else {
+        return false;
+    };
+    let first_token = first_line
+        .split(|ch: char| ch.is_ascii_whitespace() || ch == ';')
+        .next()
+        .unwrap_or_default();
+
+    first_token.eq_ignore_ascii_case("flowchart") || first_token.eq_ignore_ascii_case("graph")
+}
+
+fn first_diagram_line(source: &str) -> Option<&str> {
+    let mut in_frontmatter = false;
+    for line in source.lines().map(str::trim) {
+        if line.is_empty() {
+            continue;
+        }
+        if line == "---" {
+            in_frontmatter = !in_frontmatter;
+            continue;
+        }
+        if in_frontmatter || line.starts_with("%%") {
+            continue;
+        }
+        return Some(line);
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::render_svg;
+
+    #[test]
+    fn missing_flowchart_declaration_returns_error() {
+        let err = render_svg("this is not a mermaid diagram")
+            .expect_err("flowcharts should require an explicit declaration");
+        assert!(
+            !err.to_string().trim().is_empty(),
+            "renderer error should be non-empty"
+        );
+    }
+
+    #[test]
+    fn supported_non_flowchart_diagram_renders() {
+        let svg = render_svg(
+            "\
+sequenceDiagram
+  Alice->>Bob: Hello
+",
+        )
+        .expect("sequence diagrams should render through the renderer parser");
+        assert!(svg.contains("<svg"));
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    fn renderer_layout_panic_returns_error() {
+        let err = render_svg(
+            "\
+flowchart TD
+    Member([Member<br/>uploader])
+    Viewer([Viewer<br/>playback])
+
+    subgraph Platform[\"Platform-owned orchestration (unchanged by provider choice)\"]
+        direction LR
+        P1[Processing placeholder<br/>+ predicted completion] --- P2[Reference / copy<br/>semantics] --- P3[Webhook normalization<br/>+ realtime fan-out] --- P4[S3 Glacier<br/>source archive] --- P5[Storage accounting<br/>+ entitlement gates]
+    end
+
+    subgraph Kaltura[\"KALTURA - single vendor\"]
+        direction LR
+        K1[Upload ingest<br/>chunked, resumable] --- K2[Transcode<br/>4 HLS renditions<br/>H.264 + AAC] --- K3[Thumbnail<br/>extraction] --- K4[Captions<br/>REACH ASR] --- K5[HLS serving<br/>signed URL + CDN]
+    end
+
+    Member -->|upload| Kaltura
+    Kaltura -->|HLS playback| Viewer
+    Platform -.-> Kaltura
+
+    linkStyle 0,1,2,3,4,5,6,7 stroke:transparent,fill:none
+",
+        )
+        .expect_err("renderer panics should become render errors");
+
+        let err = err.to_string();
+        assert!(err.contains("Mermaid renderer panicked"), "{err}");
+        assert!(err.contains("subgraphs overlap"), "{err}");
+    }
+}


### PR DESCRIPTION
## Summary

Adds optional browserless Mermaid rendering behind a new `mermaid` Cargo feature. Mermaid code fences now render as SVG-backed images when the feature is enabled, while unsupported or failed diagrams fall back to normal code block rendering.

## Problem

Inlyne currently treats Mermaid fences as plain code blocks. Users who read architecture docs or technical plans in Inlyne cannot see the diagrams inline, even though the existing image pipeline already knows how to rasterize SVGs.

## Solution

This change integrates `mermaid-rs-renderer` as an optional dependency and raises the crate MSRV to Rust 1.85 to match that renderer. The interpreter now detects `mermaid` / `language-mermaid` code blocks, renders Mermaid source to SVG, converts the SVG through the existing `ImageData` rasterization path, and inserts the result as a normal image element.

Invalid Mermaid and renderer failures remain readable. The Mermaid wrapper delegates parsing and rendering to `mermaid-rs-renderer`, rejects ambiguous flowchart input without an explicit `flowchart` or `graph` declaration, and catches renderer panics so user-authored Markdown cannot take down the render path.

## Design Decisions

- Mermaid support is feature-gated to avoid adding the renderer dependency to the default build.
- Generated SVGs reuse the existing `resvg` image loading path instead of introducing a separate diagram rendering surface.
- Renderer panics are converted into normal render errors and logged by the interpreter, preserving Inlyne's existing degrade-gracefully behavior for document content.

## Blast Radius

Low-to-moderate. Default builds keep rendering Mermaid fences as code blocks. With `--features mermaid`, the affected path is fenced code block handling, SVG image decoding, and the optional Mermaid renderer dependency.

## Rollback Plan

Revert this PR. Mermaid fences will return to rendering as normal code blocks, and the optional dependency / MSRV bump will be removed.

## Test plan

- `cargo test`
- `cargo test --features mermaid`
