### PR TITLE
ci: migrate to `$GITHUB_OUTPUT`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Set the version
       id: version
       shell: bash
-      run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
+      run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
     - name: Install toolchain
       run: |
@@ -48,6 +48,7 @@ jobs:
         cargo build --target ${{ matrix.target }} --profile release-lto --locked
 
     - name: Build archive
+      id: archive
       shell: bash
       run: |
         staging="inlyne-${{ steps.version.outputs.VERSION }}-${{ matrix.target }}"
@@ -58,17 +59,17 @@ jobs:
         if [ "${{ matrix.os }}" = "windows-latest" ]; then
           cp "target/${{ matrix.target }}/release-lto/inlyne.exe" "$staging/"
           7z a "$staging.zip" "$staging"
-          echo "ASSET=$staging.zip" >> $GITHUB_ENV
+          echo "ASSET=$staging.zip" >> $GITHUB_OUTPUT
         else
           cp "target/${{ matrix.target }}/release-lto/inlyne" "$staging/"
           tar czf "$staging.tar.gz" "$staging"
-          echo "ASSET=$staging.tar.gz" >> $GITHUB_ENV
+          echo "ASSET=$staging.tar.gz" >> $GITHUB_OUTPUT
         fi
 
     - name: Upload binaries to release
       uses: svenstaro/upload-release-action@2.11.5
       with:
         repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: ${{ env.ASSET }}
-        asset_name: ${{ env.ASSET }}
+        file: ${{ steps.archive.outputs.ASSET }}
+        asset_name: ${{ steps.archive.outputs.ASSET }}
         tag: ${{ github.ref }}


### PR DESCRIPTION
`set-output` is deprecated, and `$GITHUB_OUTPUT` is more structured than `$GITHUB_ENV`