### PR TITLE
refactor: switch debug imagedata to decompress pixels

### DIFF
--- a/src/debug_impls.rs
+++ b/src/debug_impls.rs
@@ -58,14 +58,16 @@ fn debug_inline_some<T: fmt::Debug>(
     }
 }
 
-pub struct DebugBytesPrefix<'a>(pub &'a [u8]);
+pub struct DebugPrefix<'a, T>(pub &'a [T]);
 
-impl fmt::Debug for DebugBytesPrefix<'_> {
+impl<T: fmt::Debug> fmt::Debug for DebugPrefix<'_, T> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.0 {
             [x, y, z, _, ..] => {
                 let len = self.0.len();
-                f.write_fmt(format_args!("{{ len: {len}, data: [{x}, {y}, {z}, ..] }}"))
+                f.write_fmt(format_args!(
+                    "{{ len: {len}, data: [{x:?}, {y:?}, {z:?}, ..] }}"
+                ))
             }
             three_or_less => f.write_fmt(format_args!("{three_or_less:?}")),
         }

--- a/src/image/mod.rs
+++ b/src/image/mod.rs
@@ -3,6 +3,7 @@ mod decode;
 mod tests;
 
 use std::borrow::Cow;
+use std::fmt;
 use std::ops::Deref;
 use std::path::PathBuf;
 use std::str::FromStr;
@@ -13,7 +14,7 @@ use std::{
     io::{self, Read},
 };
 
-use crate::debug_impls::{DebugBytesPrefix, DebugInline};
+use crate::debug_impls::{DebugInline, DebugPrefix};
 use crate::interpreter::ImageCallback;
 use crate::metrics::{histogram, HistTag};
 use crate::positioner::DEFAULT_MARGIN;
@@ -64,13 +65,53 @@ impl ImageSize {
     }
 }
 
-#[derive(SmartDebug, Default, Clone, PartialEq)]
+struct DebugRgba([u8; 4]);
+
+impl fmt::Debug for DebugRgba {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut debug = f.debug_tuple("Rgba");
+        for b in self.0 {
+            debug.field(&format_args!("{b:x}"));
+        }
+        debug.finish()
+    }
+}
+
+struct DebugPixels(Vec<DebugRgba>);
+
+impl From<&ImageData> for DebugPixels {
+    fn from(data: &ImageData) -> Self {
+        let decompressed =
+            decode::lz4_decompress(&data.lz4_blob, data.rgba_image_byte_size()).unwrap();
+        let (pixels, rem) = decompressed.as_chunks();
+        assert_eq!(rem.len(), 0);
+        let pixels = pixels.iter().map(|&arr| DebugRgba(arr)).collect();
+        Self(pixels)
+    }
+}
+
+#[derive(Default, Clone, PartialEq)]
 pub struct ImageData {
-    #[debug(wrapper = DebugBytesPrefix)]
     lz4_blob: Vec<u8>,
     scale: bool,
-    #[debug(wrapper = DebugInline)]
     dimensions: (u32, u32),
+}
+
+impl fmt::Debug for ImageData {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let Self {
+            // handled through `DebugImageData`
+            lz4_blob: _,
+            scale,
+            dimensions,
+        } = &self;
+        let debug_pixels: DebugPixels = self.into();
+        f.debug_struct("ImageData")
+            .field("pixels", &DebugPrefix(&debug_pixels.0))
+            .field("scale", scale)
+            .field("dimensions", &DebugInline(dimensions))
+            .finish()
+    }
 }
 
 impl ImageData {

--- a/src/interpreter/snapshots/inlyne__interpreter__tests__image_loading_fails_gracefully.snap
+++ b/src/interpreter/snapshots/inlyne__interpreter__tests__image_loading_fails_gracefully.snap
@@ -1,6 +1,6 @@
 ---
 source: src/interpreter/tests.rs
-description: "![This actually returns JSON 😈](http://127.0.0.1:37929/2/snapshot.png)"
+description: "![This actually returns JSON 😈](http://127.0.0.1:40155/2/snapshot.png)"
 expression: "interpret_md_with_opts(&text, opts)"
 ---
 [
@@ -13,7 +13,7 @@ expression: "interpret_md_with_opts(&text, opts)"
                             image_data: Mutex {
                                 data: Some(
                                     ImageData {
-                                        lz4_blob: { len: 7759, data: [4, 34, 77, ..] },
+                                        pixels: { len: 4536, data: [Rgba(a1, a0, a1, ff), Rgba(a0, 9f, a0, ff), Rgba(a0, 9f, a0, ff), ..] },
                                         scale: false,
                                         dimensions: (63, 72),
                                     },

--- a/src/interpreter/snapshots/inlyne__interpreter__tests__visible_spacer_after_image.snap
+++ b/src/interpreter/snapshots/inlyne__interpreter__tests__visible_spacer_after_image.snap
@@ -13,7 +13,7 @@ expression: "interpret_md_with_opts(text, opts)"
                             image_data: Mutex {
                                 data: Some(
                                     ImageData {
-                                        lz4_blob: { len: 30, data: [4, 34, 77, ..] },
+                                        pixels: { len: 4, data: [Rgba(ff, 0, 0, ff), Rgba(0, ff, 0, ff), Rgba(0, 0, ff, ff), ..] },
                                         scale: true,
                                         dimensions: (2, 2),
                                     },

--- a/src/interpreter/tests.rs
+++ b/src/interpreter/tests.rs
@@ -842,7 +842,7 @@ fn centered_image_with_size_align_and_link() {
         image_data: Mutex {
             data: Some(
                 ImageData {
-                    lz4_blob: { len: 21244, data: [4, 34, 77, ..] },
+                    pixels: { len: 137412, data: [Rgba(0, 0, 0, 0), Rgba(0, 0, 0, 0), Rgba(0, 0, 0, 0), ..] },
                     scale: true,
                     dimensions: (396, 347),
                 },


### PR DESCRIPTION
resolves #458 

it turns out the LZ4 blobs are different on 32-bit vs 64-bit arches, so to keep the `ImageData` snapshots stable between the two the `Debug` impl internally decompresses the blob to RGBA pixels