### PR TITLE
Correctly track relative links when navigating

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -480,8 +480,19 @@ impl Inlyne {
                                             } else {
                                                 match read_to_string(&path) {
                                                     Ok(contents) => {
-                                                        self.update_file(&path, contents);
-                                                        self.opts.history.make_next(path);
+                                                        // Canonicalize before changing the CWD so
+                                                        // that the watcher and history always store
+                                                        // absolute paths, independent of CWD.
+                                                        let abs_path = path
+                                                            .canonicalize()
+                                                            .unwrap_or(path);
+                                                        self.update_file(&abs_path, contents);
+                                                        let parent = abs_path
+                                                            .parent()
+                                                            .expect("File should have parent directory");
+                                                        std::env::set_current_dir(parent)
+                                                            .expect("Could not set current directory.");
+                                                        self.opts.history.make_next(abs_path);
                                                     }
                                                     Err(err) => {
                                                         tracing::warn!(


### PR DESCRIPTION
 `Navigation fails with relative paths`

Ensure that `std::env::set_current_dir` is called when following a relative .md link. Canonicalize the path first to ensure it's unambiguously correct for the file watcher and the make_next history function.